### PR TITLE
Fix Readme and License 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Dank Memer Development
+Copyright (c) 2018-2019 Dank Memer Development
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See also the list of [contributors](https://github.com/DankMemer/webhook-server/
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These instructions will get you a copy of the project up and running on your loc
 - RethinkDB
 
 ### Installing
-1. `git clone https://github.com/Dank-Memer/webhook-server.git`
+1. `git clone https://github.com/DankMemer/webhook-server.git`
 2. Create config.json
 3. `npm i`
 4. Run rethinkdb
@@ -29,7 +29,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 * **Paradox** - *Initial work* - [ParadoxOrigins](https://github.com/ParadoxOrigins)
 
-See also the list of [contributors](https://github.com/Dank-Memer/webhook-server/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/DankMemer/webhook-server/contributors) who participated in this project.
 
 ## License
 


### PR DESCRIPTION
- License: Copyright year was left on "2018" - updated to "2018-2019"

- Readme: URL was left on `Dank-Memer` in contrast with it being updated to `DankMemer`

- Readme: License hyperlink was not working.